### PR TITLE
feat: 支持自定义品牌（本地文件读取、设置中增加开关）

### DIFF
--- a/app/src/main/java/com/drt/moisture/MainActivity.java
+++ b/app/src/main/java/com/drt/moisture/MainActivity.java
@@ -21,6 +21,7 @@ import com.drt.moisture.report.ReportActivity;
 import com.drt.moisture.setting.SettingActivity;
 import com.drt.moisture.util.AppPermission;
 import com.drt.moisture.util.CustomTextUtil;
+import com.drt.moisture.util.CustomLogoUtil;
 import com.drt.moisture.util.MyLog;
 import com.drt.moisture.util.StorageHelper;
 import com.inuker.bluetooth.library.Constants;
@@ -54,6 +55,9 @@ public class MainActivity extends BluetoothBaseActivity<MainPresenter> {
         
         // 检查存储访问权限并提示用户
         StorageHelper.checkAndPromptStorageAccess(this);
+        
+        // 确保Download目录存在
+        CustomTextUtil.createCustomTextDir();
 
         // 请求蓝牙权限
         if (!AppPermission.hasBluetoothPermissions(this)) {
@@ -77,27 +81,8 @@ public class MainActivity extends BluetoothBaseActivity<MainPresenter> {
 
         setTitle(R.string.app_name);
         
-        // 设置自定义工厂名称（完整名称）
-        TextView factoryNameText = findViewById(R.id.factory_name_text);
-        if (factoryNameText != null) {
-            MyLog.d("MainActivity", "Found factory name full TextView, loading custom text...");
-            String customFactoryName = CustomTextUtil.loadFactoryName(this, R.string.factory_name_full, false);
-            MyLog.d("MainActivity", "Setting factory name full to: " + customFactoryName);
-            factoryNameText.setText(customFactoryName);
-        } else {
-            MyLog.e("MainActivity", "Factory name full TextView not found!");
-        }
-        
-        // 设置自定义工厂名称（短名称）
-        TextView factoryShortNameText = findViewById(R.id.factory_name_short_text);
-        if (factoryShortNameText != null) {
-            MyLog.d("MainActivity", "Found factory name short TextView, loading custom text...");
-            String customFactoryShortName = CustomTextUtil.loadFactoryName(this, R.string.factory_name, true);
-            MyLog.d("MainActivity", "Setting factory name short to: " + customFactoryShortName);
-            factoryShortNameText.setText(customFactoryShortName);
-        } else {
-            MyLog.e("MainActivity", "Factory name short TextView not found!");
-        }
+        // 加载工厂名称（根据开关状态）
+        reloadFactoryNames();
     }
 
     @Override
@@ -216,23 +201,8 @@ public class MainActivity extends BluetoothBaseActivity<MainPresenter> {
     protected void onResume() {
         super.onResume();
         
-        // 每次resume时重新加载自定义工厂名称（完整名称）
-        TextView factoryNameText = findViewById(R.id.factory_name_text);
-        if (factoryNameText != null) {
-            MyLog.d("MainActivity", "onResume: Reloading factory name full...");
-            String customFactoryName = CustomTextUtil.loadFactoryName(this, R.string.factory_name_full, false);
-            MyLog.d("MainActivity", "onResume: Setting factory name full to: " + customFactoryName);
-            factoryNameText.setText(customFactoryName);
-        }
-        
-        // 每次resume时重新加载自定义工厂名称（短名称）
-        TextView factoryShortNameText = findViewById(R.id.factory_name_short_text);
-        if (factoryShortNameText != null) {
-            MyLog.d("MainActivity", "onResume: Reloading factory name short...");
-            String customFactoryShortName = CustomTextUtil.loadFactoryName(this, R.string.factory_name, true);
-            MyLog.d("MainActivity", "onResume: Setting factory name short to: " + customFactoryShortName);
-            factoryShortNameText.setText(customFactoryShortName);
-        }
+        // 每次resume时重新加载工厂名称（根据开关状态）
+        reloadFactoryNames();
         
 //        if (timer != null) {
 //            timer.cancel();
@@ -292,6 +262,43 @@ public class MainActivity extends BluetoothBaseActivity<MainPresenter> {
                     Toast.makeText(this, "拒绝蓝牙权限将无法连接设备！", Toast.LENGTH_LONG).show();
                 }
                 break;
+        }
+    }
+    
+    /**
+     * 重新加载工厂名称和logo
+     * 根据自定义品牌开关状态加载相应的工厂名称和logo
+     */
+    private void reloadFactoryNames() {
+        // 设置工厂名称（完整名称）
+        TextView factoryNameText = findViewById(R.id.factory_name_text);
+        if (factoryNameText != null) {
+            MyLog.d("MainActivity", "Loading factory name full...");
+            String customFactoryName = CustomTextUtil.loadFactoryName(this, R.string.factory_name_full, false);
+            MyLog.d("MainActivity", "Setting factory name full to: " + customFactoryName);
+            factoryNameText.setText(customFactoryName);
+        } else {
+            MyLog.e("MainActivity", "Factory name full TextView not found!");
+        }
+        
+        // 设置工厂名称（短名称）
+        TextView factoryShortNameText = findViewById(R.id.factory_name_short_text);
+        if (factoryShortNameText != null) {
+            MyLog.d("MainActivity", "Loading factory name short...");
+            String customFactoryShortName = CustomTextUtil.loadFactoryName(this, R.string.factory_name, true);
+            MyLog.d("MainActivity", "Setting factory name short to: " + customFactoryShortName);
+            factoryShortNameText.setText(customFactoryShortName);
+        } else {
+            MyLog.e("MainActivity", "Factory name short TextView not found!");
+        }
+        
+        // 重新加载logo
+        android.widget.ImageView logoImage = findViewById(R.id.logo_image);
+        if (logoImage != null) {
+            MyLog.d("MainActivity", "Reloading logo based on switch state...");
+            CustomLogoUtil.setLogoToImageView(this, logoImage);
+        } else {
+            MyLog.e("MainActivity", "Logo ImageView not found!");
         }
     }
 

--- a/app/src/main/java/com/drt/moisture/setting/SettingActivity.java
+++ b/app/src/main/java/com/drt/moisture/setting/SettingActivity.java
@@ -38,6 +38,7 @@ import com.drt.moisture.data.source.bluetooth.resquest.SetMeasureParameRequest;
 import com.drt.moisture.data.source.bluetooth.resquest.SetRateRequest;
 import com.drt.moisture.data.source.bluetooth.resquest.TimingSetRequest;
 import com.drt.moisture.util.AndroidUtil;
+import com.drt.moisture.util.CustomContentManager;
 import com.drt.moisture.util.DialogUtil;
 import com.drt.moisture.util.ExcelUtil;
 import com.inuker.bluetooth.library.Constants;
@@ -373,6 +374,11 @@ public class SettingActivity extends BluetoothBaseActivity<SettingPresenter> imp
         item1.put("title", getString(R.string.content_timing_set));
         data.add(item1);
 
+        item1 = new HashMap<>();
+        item1.put("icon", R.mipmap.icons_data_configuration);
+        item1.put("title", "自定义设置");
+        data.add(item1);
+
 //        item1 = new HashMap<>();
 //        item1.put("icon", R.mipmap.icons_recurring_appointment);
 //        item1.put("title", "查询频率");
@@ -420,7 +426,13 @@ public class SettingActivity extends BluetoothBaseActivity<SettingPresenter> imp
     public void onItemClick(final AdapterView<?> parent, final View view, final int position, long id) {
 
 
-        if (position == 6) {
+        if (position == 3) {
+            // 自定义设置 - 显示自定义品牌开关对话框
+            showCustomContentDialog();
+            return;
+        }
+        
+        if (position == 7) {
             final String[] items = {"串口", "蓝牙"};
             AlertDialog.Builder listDialog = new AlertDialog.Builder(this);
             listDialog.setTitle("请选择连接方式");
@@ -942,6 +954,10 @@ public class SettingActivity extends BluetoothBaseActivity<SettingPresenter> imp
             item1.put("icon", R.mipmap.icons_data_configuration);
             item1.put("title", "连接设置");
             data.add(item1);
+            item1 = new HashMap<>();
+            item1.put("icon", R.mipmap.icons_data_configuration);
+            item1.put("title", "自定义设置");
+            data.add(item1);
 
 
             listView.setAdapter(new SimpleAdapter(this, data,
@@ -1015,6 +1031,51 @@ public class SettingActivity extends BluetoothBaseActivity<SettingPresenter> imp
         }
 
         return ret;
+    }
+    
+    /**
+     * 显示自定义品牌开关对话框
+     */
+    private void showCustomContentDialog() {
+        CustomContentManager customContentManager = CustomContentManager.getInstance(this);
+        boolean isEnabled = customContentManager.isCustomContentEnabled();
+        
+        // 创建自定义视图
+        View dialogView = LayoutInflater.from(this).inflate(android.R.layout.select_dialog_singlechoice, null);
+        
+        // 使用简单的确认对话框来切换状态
+        String currentStatus = isEnabled ? "已启用" : "已关闭";
+        String newStatus = isEnabled ? "关闭" : "启用";
+        
+        AlertDialog.Builder builder = new AlertDialog.Builder(this);
+        builder.setTitle("自定义品牌设置");
+        builder.setMessage("当前状态：" + currentStatus + " 自定义品牌\n\n" +
+                          "启用后将使用Download/HKYQ_Moisture/目录下的自定义品牌名称和品牌图片文件\n\n" +
+                          "是否要" + newStatus + "自定义品牌？");
+        
+        builder.setPositiveButton(newStatus, new DialogInterface.OnClickListener() {
+            @Override
+            public void onClick(DialogInterface dialog, int which) {
+                boolean newEnabled = !isEnabled;
+                customContentManager.setCustomContentEnabled(newEnabled);
+                
+                String message = newEnabled ? 
+                    "已启用自定义品牌\n请将自定义文件放置在：\nDownload/HKYQ_Moisture/" : 
+                    "已关闭自定义品牌\n将使用默认的品牌名称和品牌图片";
+                Toast.makeText(SettingActivity.this, message, Toast.LENGTH_LONG).show();
+                
+                dialog.dismiss();
+            }
+        });
+        
+        builder.setNegativeButton("取消", new DialogInterface.OnClickListener() {
+            @Override
+            public void onClick(DialogInterface dialog, int which) {
+                dialog.dismiss();
+            }
+        });
+        
+        builder.show();
     }
 
 }

--- a/app/src/main/java/com/drt/moisture/util/CustomContentManager.java
+++ b/app/src/main/java/com/drt/moisture/util/CustomContentManager.java
@@ -1,0 +1,62 @@
+package com.drt.moisture.util;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+
+/**
+ * 自定义品牌管理类
+ * 管理自定义品牌名称和品牌图片的开关状态
+ */
+public class CustomContentManager {
+    
+    private static final String PREF_NAME = "custom_content_settings";
+    private static final String KEY_CUSTOM_CONTENT_ENABLED = "custom_content_enabled";
+    
+    private static CustomContentManager instance;
+    private SharedPreferences sharedPreferences;
+    
+    private CustomContentManager(Context context) {
+        sharedPreferences = context.getApplicationContext().getSharedPreferences(PREF_NAME, Context.MODE_PRIVATE);
+    }
+    
+    /**
+     * 获取单例实例
+     */
+    public static synchronized CustomContentManager getInstance(Context context) {
+        if (instance == null) {
+            instance = new CustomContentManager(context);
+        }
+        return instance;
+    }
+    
+    /**
+     * 设置是否启用自定义品牌
+     * @param enabled true=启用自定义品牌，false=使用默认内容
+     */
+    public void setCustomContentEnabled(boolean enabled) {
+        sharedPreferences.edit()
+            .putBoolean(KEY_CUSTOM_CONTENT_ENABLED, enabled)
+            .apply();
+        MyLog.d("CustomContentManager", "Custom content enabled: " + enabled);
+    }
+    
+    /**
+     * 获取是否启用自定义品牌
+     * @return true=启用自定义品牌，false=使用默认内容
+     */
+    public boolean isCustomContentEnabled() {
+        boolean enabled = sharedPreferences.getBoolean(KEY_CUSTOM_CONTENT_ENABLED, false);
+        MyLog.d("CustomContentManager", "Custom content enabled: " + enabled);
+        return enabled;
+    }
+    
+    /**
+     * 重置所有设置为默认值
+     */
+    public void resetToDefaults() {
+        sharedPreferences.edit()
+            .putBoolean(KEY_CUSTOM_CONTENT_ENABLED, false)
+            .apply();
+        MyLog.d("CustomContentManager", "Reset custom content settings to defaults");
+    }
+}

--- a/app/src/main/java/com/drt/moisture/util/CustomLogoUtil.java
+++ b/app/src/main/java/com/drt/moisture/util/CustomLogoUtil.java
@@ -17,13 +17,13 @@ import java.io.File;
 
 public class CustomLogoUtil {
     
-    private static final String CUSTOM_LOGO_DIR = "QUAKE_Moisture";
+    private static final String CUSTOM_LOGO_DIR = "HKYQ_Moisture";
     private static final String CUSTOM_LOGO_FILENAME = "custom_logo.png";
     
     /**
      * 获取自定义logo的完整路径
      * 使用Download目录，这个目录在Android 15中更容易访问
-     * 路径: /storage/emulated/0/Download/QUAKE_Moisture/custom_logo.png
+     * 路径: /storage/emulated/0/Download/HKYQ_Moisture/custom_logo.png
      */
     public static String getCustomLogoPath() {
         // 使用Download目录，这在Android所有版本中都比较容易访问
@@ -36,9 +36,16 @@ public class CustomLogoUtil {
     }
     
     /**
-     * 检查自定义logo是否存在
+     * 检查自定义logo是否存在并且开关已启用
      */
-    public static boolean isCustomLogoExists() {
+    public static boolean isCustomLogoExists(Context context) {
+        // 首先检查自定义品牌开关是否启用
+        CustomContentManager customContentManager = CustomContentManager.getInstance(context);
+        if (!customContentManager.isCustomContentEnabled()) {
+            MyLog.d("CustomLogoUtil", "Custom content disabled, using default logo");
+            return false;
+        }
+        
         File logoFile = new File(getCustomLogoPath());
         boolean exists = logoFile.exists();
         boolean isFile = logoFile.isFile();
@@ -47,10 +54,10 @@ public class CustomLogoUtil {
         MyLog.d("CustomLogoUtil", "Logo file exists: " + exists + ", isFile: " + isFile + ", size: " + size);
         
         if (exists && isFile && size > 0) {
-            MyLog.d("CustomLogoUtil", "Custom logo found, using custom logo");
+            MyLog.d("CustomLogoUtil", "Custom logo found and enabled, using custom logo");
             return true;
         } else {
-            MyLog.d("CustomLogoUtil", "Custom logo not found, using default logo");
+            MyLog.d("CustomLogoUtil", "Custom logo not found or disabled, using default logo");
             return false;
         }
     }
@@ -63,7 +70,7 @@ public class CustomLogoUtil {
     public static Drawable loadLogoDrawable(Context context) {
         MyLog.d("CustomLogoUtil", "Loading logo drawable...");
         
-        if (isCustomLogoExists()) {
+        if (isCustomLogoExists(context)) {
             try {
                 String logoPath = getCustomLogoPath();
                 MyLog.d("CustomLogoUtil", "Attempting to load custom logo from: " + logoPath);

--- a/app/src/main/java/com/drt/moisture/util/CustomTextUtil.java
+++ b/app/src/main/java/com/drt/moisture/util/CustomTextUtil.java
@@ -1,12 +1,9 @@
 package com.drt.moisture.util;
 
 import android.content.Context;
-import android.os.Build;
+import android.graphics.Bitmap;
+import android.graphics.BitmapFactory;
 import android.os.Environment;
-import android.provider.MediaStore;
-import android.database.Cursor;
-import android.content.ContentResolver;
-import android.net.Uri;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -16,14 +13,18 @@ import java.io.InputStream;
 
 public class CustomTextUtil {
     
-    private static final String CUSTOM_TEXT_DIR = "QUAKE_Moisture";
+    private static final String CUSTOM_TEXT_DIR = "HKYQ_Moisture";
     private static final String FACTORY_NAME_FILENAME = "factory_name.txt";
     private static final String FACTORY_NAME_SHORT_FILENAME = "factory_name_short.txt";
+    
+    // 自定义图片文件名
+    private static final String CUSTOM_LOGO_FILENAME = "custom_logo.png";
+    private static final String CUSTOM_BACKGROUND_FILENAME = "custom_background.png";
     
     /**
      * 获取自定义工厂名称文件的完整路径
      * 优先使用Download目录，这个目录在Android 15中更容易访问
-     * 路径: /storage/emulated/0/Download/QUAKE_Moisture/factory_name.txt
+     * 路径: /storage/emulated/0/Download/HKYQ_Moisture/factory_name.txt
      */
     public static String getFactoryNameFilePath() {
         return getFactoryNameFilePath(false);
@@ -31,44 +32,14 @@ public class CustomTextUtil {
     
     /**
      * 获取自定义工厂名称文件的完整路径
+     * 统一使用Download目录，方便运营人员通过文件管理器编辑
      * @param isShort true=获取短名称文件路径，false=获取完整名称文件路径
      */
     public static String getFactoryNameFilePath(boolean isShort) {
-        File textFile;
-        
-        // 针对Android 14+优化存储访问
-        if (Build.VERSION.SDK_INT >= 34) { // Android 14+ (API 34+)
-            // 优先使用应用专用存储目录
-            File appExternalDir = new File(Environment.getExternalStorageDirectory(), "Android/data/com.drt.moisture/files/Documents");
-            if (!appExternalDir.exists()) {
-                appExternalDir.mkdirs();
-            }
-            File textDir = new File(appExternalDir, CUSTOM_TEXT_DIR);
-            String filename = isShort ? FACTORY_NAME_SHORT_FILENAME : FACTORY_NAME_FILENAME;
-            textFile = new File(textDir, filename);
-            
-            // 如果应用专用目录文件不存在，尝试从Download目录复制
-            if (!textFile.exists()) {
-                File downloadDir = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS);
-                File downloadTextDir = new File(downloadDir, CUSTOM_TEXT_DIR);
-                File downloadTextFile = new File(downloadTextDir, filename);
-                if (downloadTextFile.exists()) {
-                    try {
-                        textDir.mkdirs();
-                        copyFile(downloadTextFile, textFile);
-                        MyLog.d("CustomTextUtil", "Copied file from Download to app storage: " + textFile.getAbsolutePath());
-                    } catch (Exception e) {
-                        MyLog.e("CustomTextUtil", "Failed to copy file: " + e.getMessage());
-                    }
-                }
-            }
-        } else {
-            // Android 13及以下版本使用传统方式
-            File downloadDir = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS);
-            File textDir = new File(downloadDir, CUSTOM_TEXT_DIR);
-            String filename = isShort ? FACTORY_NAME_SHORT_FILENAME : FACTORY_NAME_FILENAME;
-            textFile = new File(textDir, filename);
-        }
+        File downloadDir = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS);
+        File textDir = new File(downloadDir, CUSTOM_TEXT_DIR);
+        String filename = isShort ? FACTORY_NAME_SHORT_FILENAME : FACTORY_NAME_FILENAME;
+        File textFile = new File(textDir, filename);
         
         MyLog.d("CustomTextUtil", "Factory name file path (" + (isShort ? "short" : "full") + "): " + textFile.getAbsolutePath());
         return textFile.getAbsolutePath();
@@ -122,15 +93,21 @@ public class CustomTextUtil {
      */
     public static String loadFactoryName(Context context, String defaultFactoryName, boolean isShort) {
         String fileType = isShort ? "short" : "full";
-        String filename = isShort ? FACTORY_NAME_SHORT_FILENAME : FACTORY_NAME_FILENAME;
         MyLog.d("CustomTextUtil", "Loading factory name (" + fileType + ")...");
+        
+        // 检查是否启用自定义品牌
+        CustomContentManager customContentManager = CustomContentManager.getInstance(context);
+        if (!customContentManager.isCustomContentEnabled()) {
+            MyLog.d("CustomTextUtil", "Custom content disabled, using default factory name (" + fileType + "): " + defaultFactoryName);
+            return defaultFactoryName;
+        }
         
         // 首先尝试创建目录
         createCustomTextDir();
         
-        // 使用StorageHelper获取文件路径
-        String filePath = StorageHelper.readFileFromMultipleLocations(context, filename);
-        if (filePath != null && StorageHelper.isFileReadable(filePath)) {
+        // 直接从Download目录读取文件
+        String filePath = getFactoryNameFilePath(isShort);
+        if (StorageHelper.isFileReadable(filePath)) {
             try {
                 MyLog.d("CustomTextUtil", "Attempting to load factory name (" + fileType + ") from: " + filePath);
                 
@@ -165,15 +142,6 @@ public class CustomTextUtil {
             }
         }
         
-        // Android 14+ 使用媒体存储API作为备用方案
-        if (Build.VERSION.SDK_INT >= 34) {
-            String content = loadFactoryNameFromMediaStore(context, isShort);
-            if (content != null && !content.isEmpty()) {
-                MyLog.d("CustomTextUtil", "Successfully loaded custom factory name (" + fileType + ") from MediaStore: " + content);
-                return content;
-            }
-        }
-        
         MyLog.d("CustomTextUtil", "Using default factory name (" + fileType + "): " + defaultFactoryName);
         return defaultFactoryName;
     }
@@ -203,96 +171,105 @@ public class CustomTextUtil {
     
     /**
      * 创建自定义文本目录
+     * 统一使用Download目录
      */
     public static boolean createCustomTextDir() {
         try {
-            // Android 14+ 优先使用应用专用存储
-            if (Build.VERSION.SDK_INT >= 34) {
-                File appExternalDir = new File(Environment.getExternalStorageDirectory(), "Android/data/com.drt.moisture/files/Documents");
-                File textDir = new File(appExternalDir, CUSTOM_TEXT_DIR);
-                
-                if (!textDir.exists()) {
-                    boolean created = textDir.mkdirs();
-                    MyLog.d("CustomTextUtil", "App-specific text directory created: " + created + ", path: " + textDir.getAbsolutePath());
-                    return created;
-                }
-                return true;
-            } else {
-                // 传统方式：使用Download目录
-                File downloadDir = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS);
-                File textDir = new File(downloadDir, CUSTOM_TEXT_DIR);
-                
-                if (!textDir.exists()) {
-                    boolean created = textDir.mkdirs();
-                    MyLog.d("CustomTextUtil", "Text directory created: " + created + ", path: " + textDir.getAbsolutePath());
-                    return created;
-                }
-                return true;
+            File downloadDir = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS);
+            File textDir = new File(downloadDir, CUSTOM_TEXT_DIR);
+            
+            if (!textDir.exists()) {
+                boolean created = textDir.mkdirs();
+                MyLog.d("CustomTextUtil", "Download text directory created: " + created + ", path: " + textDir.getAbsolutePath());
+                return created;
             }
+            MyLog.d("CustomTextUtil", "Download text directory already exists: " + textDir.getAbsolutePath());
+            return true;
         } catch (Exception e) {
             MyLog.e("CustomTextUtil", "Failed to create custom text directory: " + e.getMessage());
             return false;
         }
     }
     
+    
     /**
-     * 通过MediaStore API加载工厂名称文件（Android 14+兼容）
+     * 加载自定义logo图片
+     * @param context 上下文
+     * @return Bitmap对象，如果未启用自定义品牌或文件不存在则返回null
      */
-    private static String loadFactoryNameFromMediaStore(Context context, boolean isShort) {
-        try {
-            String filename = isShort ? FACTORY_NAME_SHORT_FILENAME : FACTORY_NAME_FILENAME;
-            String relativePath = "Download/" + CUSTOM_TEXT_DIR + "/" + filename;
-            
-            // 使用MediaStore查询文件
-            ContentResolver resolver = context.getContentResolver();
-            Uri uri = MediaStore.Files.getContentUri("external");
-            
-            String[] projection = {MediaStore.Files.FileColumns._ID, MediaStore.Files.FileColumns.DISPLAY_NAME};
-            String selection = MediaStore.Files.FileColumns.RELATIVE_PATH + "=? AND " + 
-                             MediaStore.Files.FileColumns.DISPLAY_NAME + "=?";
-            String[] selectionArgs = {"Download/" + CUSTOM_TEXT_DIR + "/", filename};
-            
-            Cursor cursor = resolver.query(uri, projection, selection, selectionArgs, null);
-            
-            if (cursor != null && cursor.moveToFirst()) {
-                int idColumn = cursor.getColumnIndexOrThrow(MediaStore.Files.FileColumns._ID);
-                long id = cursor.getLong(idColumn);
-                Uri fileUri = Uri.withAppendedPath(uri, String.valueOf(id));
-                
-                InputStream inputStream = resolver.openInputStream(fileUri);
-                if (inputStream != null) {
-                    InputStreamReader isr = new InputStreamReader(inputStream, "UTF-8");
-                    BufferedReader br = new BufferedReader(isr);
-                    
-                    StringBuilder content = new StringBuilder();
-                    String line;
-                    while ((line = br.readLine()) != null) {
-                        if (content.length() > 0) {
-                            content.append("\n");
-                        }
-                        content.append(line);
-                    }
-                    
-                    br.close();
-                    isr.close();
-                    inputStream.close();
-                    cursor.close();
-                    
-                    String result = content.toString().trim();
-                    MyLog.d("CustomTextUtil", "Loaded factory name from MediaStore: " + result);
-                    return result;
+    public static Bitmap loadCustomLogo(Context context) {
+        return loadCustomImage(context, CUSTOM_LOGO_FILENAME);
+    }
+    
+    /**
+     * 加载自定义背景图片
+     * @param context 上下文
+     * @return Bitmap对象，如果未启用自定义品牌或文件不存在则返回null
+     */
+    public static Bitmap loadCustomBackground(Context context) {
+        return loadCustomImage(context, CUSTOM_BACKGROUND_FILENAME);
+    }
+    
+    /**
+     * 加载自定义图片的通用方法
+     * @param context 上下文
+     * @param filename 图片文件名
+     * @return Bitmap对象，如果未启用自定义品牌或文件不存在则返回null
+     */
+    private static Bitmap loadCustomImage(Context context, String filename) {
+        MyLog.d("CustomTextUtil", "Loading custom image: " + filename);
+        
+        // 检查是否启用自定义品牌
+        CustomContentManager customContentManager = CustomContentManager.getInstance(context);
+        if (!customContentManager.isCustomContentEnabled()) {
+            MyLog.d("CustomTextUtil", "Custom content disabled, skipping image load: " + filename);
+            return null;
+        }
+        
+        // 构建图片文件路径
+        File downloadDir = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS);
+        File imageDir = new File(downloadDir, CUSTOM_TEXT_DIR);
+        File imageFile = new File(imageDir, filename);
+        
+        if (imageFile.exists() && imageFile.canRead()) {
+            try {
+                MyLog.d("CustomTextUtil", "Loading custom image from: " + imageFile.getAbsolutePath());
+                Bitmap bitmap = BitmapFactory.decodeFile(imageFile.getAbsolutePath());
+                if (bitmap != null) {
+                    MyLog.d("CustomTextUtil", "Successfully loaded custom image: " + filename + " (" + bitmap.getWidth() + "x" + bitmap.getHeight() + ")");
+                    return bitmap;
+                } else {
+                    MyLog.w("CustomTextUtil", "Failed to decode image file: " + filename);
                 }
+            } catch (Exception e) {
+                MyLog.e("CustomTextUtil", "Error loading custom image: " + e.getMessage());
+                e.printStackTrace();
             }
-            
-            if (cursor != null) {
-                cursor.close();
-            }
-        } catch (Exception e) {
-            MyLog.e("CustomTextUtil", "Failed to load factory name from MediaStore: " + e.getMessage());
-            e.printStackTrace();
+        } else {
+            MyLog.d("CustomTextUtil", "Custom image file not found or not readable: " + imageFile.getAbsolutePath());
         }
         
         return null;
+    }
+    
+    /**
+     * 检查自定义图片是否存在
+     * @param context 上下文
+     * @param filename 图片文件名
+     * @return true=文件存在且可读，false=文件不存在或不可读
+     */
+    public static boolean isCustomImageAvailable(Context context, String filename) {
+        // 检查是否启用自定义品牌
+        CustomContentManager customContentManager = CustomContentManager.getInstance(context);
+        if (!customContentManager.isCustomContentEnabled()) {
+            return false;
+        }
+        
+        File downloadDir = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS);
+        File imageDir = new File(downloadDir, CUSTOM_TEXT_DIR);
+        File imageFile = new File(imageDir, filename);
+        
+        return imageFile.exists() && imageFile.canRead() && imageFile.length() > 0;
     }
     
     /**

--- a/app/src/main/java/com/drt/moisture/util/StorageHelper.java
+++ b/app/src/main/java/com/drt/moisture/util/StorageHelper.java
@@ -35,20 +35,10 @@ public class StorageHelper {
     
     /**
      * 获取推荐的存储目录
+     * 统一使用Download目录，方便运营人员通过文件管理器编辑
      */
     public static File getRecommendedStorageDirectory(Context context) {
-        if (Build.VERSION.SDK_INT >= 34) {
-            // Android 14+ 优先使用应用专用目录
-            File appExternalDir = new File(Environment.getExternalStorageDirectory(), 
-                                         "Android/data/" + context.getPackageName() + "/files/Documents");
-            if (!appExternalDir.exists()) {
-                appExternalDir.mkdirs();
-            }
-            return appExternalDir;
-        } else {
-            // 传统方式使用Download目录
-            return Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS);
-        }
+        return Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS);
     }
     
     /**
@@ -105,14 +95,14 @@ public class StorageHelper {
     private static void showStorageInstructionDialog(Activity activity) {
         AlertDialog.Builder builder = new AlertDialog.Builder(activity);
         builder.setTitle("自定义工厂名称使用说明");
-        builder.setMessage("在Android 14+系统中，您可以通过以下方式使用自定义工厂名称：\n\n" +
-                         "方式1：将文件放在应用专用目录\n" +
-                         "• 路径：Android/data/com.drt.moisture/files/Documents/QUAKE_Moisture/\n" +
-                         "• 文件：factory_name.txt（完整名称）\n" +
-                         "• 文件：factory_name_short.txt（短名称）\n\n" +
-                         "方式2：授予完整存储权限\n" +
-                         "• 在设置中允许应用访问「所有文件」\n" +
-                         "• 然后将文件放在：Download/QUAKE_Moisture/ 目录中");
+        builder.setMessage("要使用自定义工厂名称，请按以下步骤操作：\n\n" +
+                         "1. 在设置中允许应用访问「所有文件」\n\n" +
+                         "2. 将自定义文件放在以下目录：\n" +
+                         "   Download/HKYQ_Moisture/\n\n" +
+                         "3. 文件名称：\n" +
+                         "   • factory_name.txt（完整名称）\n" +
+                         "   • factory_name_short.txt（短名称）\n\n" +
+                         "文件可通过任何文件管理器编辑");
         
         builder.setPositiveButton("知道了", new DialogInterface.OnClickListener() {
             @Override
@@ -125,28 +115,19 @@ public class StorageHelper {
     }
     
     /**
-     * 尝试从多个位置读取文件
+     * 从Download目录读取文件
+     * 统一使用Download目录，简化逻辑
      */
     public static String readFileFromMultipleLocations(Context context, String fileName) {
-        // 位置1：应用专用目录（Android 14+优先）
-        if (Build.VERSION.SDK_INT >= 34) {
-            File appDir = new File(getRecommendedStorageDirectory(context), "QUAKE_Moisture");
-            File appFile = new File(appDir, fileName);
-            if (isFileReadable(appFile.getAbsolutePath())) {
-                MyLog.d("StorageHelper", "Reading from app-specific directory: " + appFile.getAbsolutePath());
-                return appFile.getAbsolutePath();
-            }
-        }
-        
-        // 位置2：Download目录（传统位置）
         File downloadDir = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS);
-        File downloadFile = new File(new File(downloadDir, "QUAKE_Moisture"), fileName);
+        File downloadFile = new File(new File(downloadDir, "HKYQ_Moisture"), fileName);
+        
         if (isFileReadable(downloadFile.getAbsolutePath())) {
             MyLog.d("StorageHelper", "Reading from Download directory: " + downloadFile.getAbsolutePath());
             return downloadFile.getAbsolutePath();
         }
         
-        MyLog.w("StorageHelper", "File not found in any location: " + fileName);
+        MyLog.w("StorageHelper", "File not found in Download directory: " + fileName);
         return null;
     }
     
@@ -154,22 +135,20 @@ public class StorageHelper {
      * 检查并提示用户如何解决存储访问问题
      */
     public static void checkAndPromptStorageAccess(Activity activity) {
-        if (Build.VERSION.SDK_INT >= 34) {
-            if (!canAccessExternalStorage(activity)) {
-                MyLog.w("StorageHelper", "Storage access limited on Android 14+");
-                
-                // 检查是否有自定义文件在传统位置
-                boolean hasFileInDownload = isFileReadable(
-                    Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS) + 
-                    "/QUAKE_Moisture/factory_name.txt") ||
-                    isFileReadable(
-                    Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS) + 
-                    "/QUAKE_Moisture/factory_name_short.txt");
-                
-                if (hasFileInDownload) {
-                    // 如果在Download目录有文件但无法访问，提示用户
-                    showStoragePermissionDialog(activity);
-                }
+        if (!canAccessExternalStorage(activity)) {
+            MyLog.w("StorageHelper", "Storage access limited, may need MANAGE_EXTERNAL_STORAGE permission");
+            
+            // 检查是否有自定义文件在Download目录
+            boolean hasFileInDownload = isFileReadable(
+                Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS) + 
+                "/HKYQ_Moisture/factory_name.txt") ||
+                isFileReadable(
+                Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS) + 
+                "/HKYQ_Moisture/factory_name_short.txt");
+            
+            if (hasFileInDownload) {
+                // 如果在Download目录有文件但无法访问，提示用户
+                showStoragePermissionDialog(activity);
             }
         }
     }

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -28,12 +28,15 @@
 
             <ImageView
                 android:id="@+id/logo_image"
-                android:layout_width="wrap_content"
+                android:layout_width="169dp"
                 android:layout_height="match_parent"
                 android:src="@mipmap/logo_title"
                 android:paddingTop="8dp"
                 android:paddingBottom="8dp"
                 android:paddingLeft="8dp"
+                android:paddingRight="8dp"
+                android:scaleType="fitStart"
+                android:adjustViewBounds="true"
                 />
 
 

--- a/app/src/main/res/layout/widget_tool_bar.xml
+++ b/app/src/main/res/layout/widget_tool_bar.xml
@@ -14,12 +14,15 @@
 
     <ImageView
         android:id="@+id/logo_image"
-        android:layout_width="wrap_content"
+        android:layout_width="169dp"
         android:layout_height="match_parent"
         android:src="@mipmap/logo_title"
         android:paddingTop="8dp"
         android:paddingBottom="8dp"
         android:paddingLeft="8dp"
+        android:paddingRight="8dp"
+        android:scaleType="fitStart"
+        android:adjustViewBounds="true"
         />
 
     <TextView

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -23,7 +23,7 @@
     <dimen name="sizeThreeBody">10sp</dimen>
 
     <dimen name="home_card_width">240dp</dimen>
-    <dimen name="home_card_height">72dp</dimen>
+    <dimen name="home_card_height">80dp</dimen>
     <dimen name="home_card_margin">32dp</dimen>
     <dimen name="home_card_radius">8dp</dimen>
 


### PR DESCRIPTION
## Summary
- 新增自定义品牌内容管理功能，支持从Download/HKYQ_Moisture/目录读取自定义工厂名称和logo
- 在设置页面添加自定义品牌开关，用户可启用/关闭自定义内容功能
- 优化logo布局，固定宽度为169dp，确保左对齐显示

## 主要功能
- ✅ 新增CustomContentManager类管理自定义内容开关状态
- ✅ 修改CustomTextUtil支持开关控制的工厂名称加载
- ✅ 修改CustomLogoUtil支持开关控制的logo加载
- ✅ 在设置页面添加"自定义品牌设置"选项
- ✅ 支持动态切换自定义内容和默认内容
- ✅ 优化logo布局，固定宽度169dp，左对齐显示

## 文件变更
- 新增：`CustomContentManager.java` - 自定义内容管理类
- 修改：`MainActivity.java` - 增加logo重新加载功能
- 修改：`SettingActivity.java` - 添加自定义品牌设置选项
- 修改：`CustomTextUtil.java` - 支持开关控制
- 修改：`CustomLogoUtil.java` - 支持开关控制
- 修改：布局文件 - 优化logo显示

## 使用方式
1. 将自定义文件放置在：`/storage/emulated/0/Download/HKYQ_Moisture/`
2. 支持的文件：
   - `factory_name.txt` - 完整工厂名称
   - `factory_name_short.txt` - 短工厂名称
   - `custom_logo.png` - 自定义logo
3. 在设置页面启用"自定义品牌"开关
4. 应用将自动使用自定义内容

## Test plan
- [x] 编译测试通过
- [x] 验证设置页面显示自定义品牌选项
- [x] 验证开关功能正常工作
- [x] 验证logo布局正确显示
- [x] 验证自定义内容加载逻辑

🤖 Generated with [Claude Code](https://claude.ai/code)